### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-##Knowledge Sharing Platform
+## Knowledge Sharing Platform
 
 The Knowledge Sharing Platform (K#) is a platform that aims to develop a sophisticated enterprise knowledge graph using a wide variety of large-scale data sources. To realise this platform, we are developing a set of components for collecting, extracting, transforming, integrating, and updating knowledge sources. 
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
